### PR TITLE
Replace removed update_attributes method in rails 6

### DIFF
--- a/app/controllers/mosaico/projects_controller.rb
+++ b/app/controllers/mosaico/projects_controller.rb
@@ -14,7 +14,7 @@ module Mosaico
 
     def update
       project = Mosaico::Project.find(params[:id])
-      project.update_attributes(project_params)
+      project.update(project_params)
       render json: { project_id: project.id }, status: :ok
     end
 


### PR DESCRIPTION
In rails 5 the `update_attributes` method was deprecated and in rails 6, the method has been removed.

This PR replaces the usage with the recommended `update` method.